### PR TITLE
Resolve Cross-site POST form submissions are forbidden issue

### DIFF
--- a/lambda/serverless.js
+++ b/lambda/serverless.js
@@ -5,11 +5,12 @@ import { manifest } from '../manifest.js';
 const server = new Server(manifest);
 
 export async function handler(event) {
-  const { path, method } = getVersionRoute[event.version ?? '1.0']?.(event)
-  const { headers, body, multiValueQueryStringParameters, requestContext, isBase64Encoded } = event;
+  const { path, method } = getVersionRoute[event.version ?? '1.0']?.(event);
+  const { headers, body, multiValueQueryStringParameters, isBase64Encoded } = event;
   const encoding = isBase64Encoded ? 'base64' : (headers && headers['content-encoding']) || 'utf-8';
   const rawBody = typeof body === 'string' ? Buffer.from(body, encoding) : body;
-  const rawURL = `https://${requestContext.domainName}${path}${parseQuery(multiValueQueryStringParameters)}`;
+  headers.origin = process.env.ORIGIN ?? headers.origin;
+  const rawURL = `${headers.origin}${path}${parseQuery(multiValueQueryStringParameters)}`;
 
   await server.init({ env: process.env });
 
@@ -59,13 +60,13 @@ export async function handler(event) {
 const getVersionRoute = {
   '1.0': (event) => ({
     method: event.httpMethod,
-    path: event.path
+    path: event.path,
   }),
   '2.0': (event) => ({
     method: event.requestContext.http.method,
-    path: event.requestContext.http.path
-  })
-}
+    path: event.requestContext.http.path,
+  }),
+};
 
 function parseQuery(queryParams) {
   if (!queryParams) return '';


### PR DESCRIPTION
Resolve https://github.com/sveltejs/kit/issues/6589 for this adapter in similar way as `adapter-node`.

Possible improvement, set the env during the build process and have env injected in without needing to set on the lambda (closer to how `adapter-node` works I think).