### PR TITLE
write routes to build/routes.json

### DIFF
--- a/adapter.ts
+++ b/adapter.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { spawnSync } from 'child_process';
 import * as esbuild from 'esbuild';
 import { config } from 'dotenv';
+import {writeFileSync} from "fs";
 const updateDotenv = require('update-dotenv');
 
 export interface AWSAdapterProps {
@@ -90,6 +91,8 @@ export function adapter({
             .filter(Boolean)
         ),
       ];
+
+      writeFileSync(join(artifactPath, 'routes.json'), JSON.stringify(routes))
 
       builder.log.minor('Deploy using AWS-CDK.');
       autoDeploy &&


### PR DESCRIPTION
Working on integrating the `AWSAdapterStack` into my own cdk project. Running into a few hiccups, but this is the main one. When using autodeploy, routes are sent to cdk through environment variables. In my case, I do not want build and deploy to be linked, so that data needs to be saved for later.

I think it would also just be better if `lib/adapter-stack.ts` would just read this file instead of reading from environment. Or something like `process.env.ROUTES || readFileSync()`. But, I will leave that part up to you.