### PR TITLE
Fix server policies

### DIFF
--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import {App, Tags} from 'aws-cdk-lib';
-import {AWSAdapterStack} from '../lib/adapter-stack';
+import { App, Tags } from 'aws-cdk-lib';
+import { AWSAdapterStack } from '../lib/adapter-stack';
 
 const app = new App();
 Tags.of(app).add('app', 'sveltekit-adapter-aws-webapp');
 
 new AWSAdapterStack(app, process.env.STACKNAME!, {
-    FQDN: process.env.FQDN!,
-    env: {
-        account: process.env.CDK_DEFAULT_ACCOUNT,
-        region: process.env.CDK_DEFAULT_REGION,
-    },
+  FQDN: process.env.FQDN!,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
 });

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import { App, Tags } from 'aws-cdk-lib';
-import { AWSAdapterStack } from '../lib/adapter-stack';
+import {App, Tags} from 'aws-cdk-lib';
+import {AWSAdapterStack} from '../lib/adapter-stack';
 
 const app = new App();
 Tags.of(app).add('app', 'sveltekit-adapter-aws-webapp');
 
 new AWSAdapterStack(app, process.env.STACKNAME!, {
-  FQDN: process.env.FQDN!,
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
+    FQDN: process.env.FQDN!,
+    env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+    },
 });

--- a/lib/adapter-stack.ts
+++ b/lib/adapter-stack.ts
@@ -60,7 +60,7 @@ export class AWSAdapterStack extends Stack {
       } as any,
     });
 
-    props.serverHandlerPolicies?.forEach(policy => this.serverHandler.addToRolePolicy(policy));
+    props.serverHandlerPolicies?.forEach((policy) => this.serverHandler.addToRolePolicy(policy));
 
     this.httpApi = new HttpApi(this, 'API', {
       corsPreflight: {

--- a/lib/adapter-stack.ts
+++ b/lib/adapter-stack.ts
@@ -60,7 +60,7 @@ export class AWSAdapterStack extends Stack {
       } as any,
     });
 
-    props.serverHandlerPolicies?.forEach(this.serverHandler.addToRolePolicy);
+    props.serverHandlerPolicies?.forEach(policy => this.serverHandler.addToRolePolicy(policy));
 
     this.httpApi = new HttpApi(this, 'API', {
       corsPreflight: {


### PR DESCRIPTION
Sorry to be changing this already, but my last pr was a draft. 

As far as I understand Node, there should be no difference in functionality between these two statements, but the former was causing it to blow up. Being more explicit in my lambda seems to fix the problem though.

```
/Users/caleb/repos/cdk/node_modules/.pnpm/aws-cdk-lib@2.50.0_constructs@10.1.155/node_modules/aws-cdk-lib/aws-lambda/lib/function-base.js:2
`))}addPermission(id,permission){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_lambda_Permission(permission)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.addPermission),error}if(!this.canCreatePermissions)return;let principal=this.parsePermissionPrincipal(permission.principal),{sourceArn,sourceAccount,principalOrgID}=this.validateConditionCombinations(permission.principal)??{};const action=permission.action??"lambda:InvokeFunction",scope=permission.scope??this;this.considerWarningOnInvokeFunctionPermissions(scope,action),new lambda_generated_1.CfnPermission(scope,id,{action,principal,functionName:this.functionArn,eventSourceToken:permission.eventSourceToken,sourceAccount:permission.sourceAccount??sourceAccount,sourceArn:permission.sourceArn??sourceArn,principalOrgId:permission.organizationId??principalOrgID,functionUrlAuthType:permission.functionUrlAuthType})}addToRolePolicy(statement){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_iam_PolicyStatement(statement)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.addToRolePolicy),error}!this.role||this.role.addToPrincipalPolicy(statement)}get connections(){if(!this._connections)throw new Error('Only VPC-associated Lambda Functions have security groups to manage. Supply the "vpc" parameter when creating the Lambda, or "securityGroupId" when importing it.');return this._connections}get latestVersion(){return this._latestVersion||(this._latestVersion=new LatestVersion(this)),this._latestVersion}get isBoundToVpc(){return!!this._connections}addEventSourceMapping(id,options){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_lambda_EventSourceMappingOptions(options)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.addEventSourceMapping),error}return new event_source_mapping_1.EventSourceMapping(this,id,{target:this,...options})}grantInvoke(grantee){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_iam_IGrantable(grantee)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.grantInvoke),error}const identifier=`Invoke${crypto_1.createHash("sha256").update(JSON.stringify({principal:grantee.grantPrincipal.toString(),conditions:grantee.grantPrincipal.policyFragment.conditions}),"utf8").digest("base64")}`;let grant=this._invocationGrants[identifier];return grant||(grant=this.grant(grantee,identifier,"lambda:InvokeFunction",this.resourceArnsForGrantInvoke),this._invocationGrants[identifier]=grant),grant}grantInvokeUrl(grantee){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_iam_IGrantable(grantee)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.grantInvokeUrl),error}const identifier=`InvokeFunctionUrl${grantee.grantPrincipal}`;let grant=this._functionUrlInvocationGrants[identifier];return grant||(grant=this.grant(grantee,identifier,"lambda:InvokeFunctionUrl",[this.functionArn],{functionUrlAuthType:function_url_1.FunctionUrlAuthType.AWS_IAM}),this._functionUrlInvocationGrants[identifier]=grant),grant}addEventSource(source){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_lambda_IEventSource(source)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.addEventSource),error}source.bind(this)}configureAsyncInvoke(options){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_lambda_EventInvokeConfigOptions(options)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.configureAsyncInvoke),error}if(this.node.tryFindChild("EventInvokeConfig")!==void 0)throw new Error(`An EventInvokeConfig has already been configured for the function at ${this.node.path}`);new event_invoke_config_1.EventInvokeConfig(this,"EventInvokeConfig",{function:this,...options})}addFunctionUrl(options){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_lambda_FunctionUrlOptions(options)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.addFunctionUrl),error}return new function_url_1.FunctionUrl(this,"FunctionUrl",{function:this,...options})}_functionNode(){return this.node}_isStackAccount(){return core_1.Token.isUnresolved(this.stack.account)||core_1.Token.isUnresolved(this.functionArn)?!1:this.stack.splitArn(this.functionArn,core_1.ArnFormat.SLASH_RESOURCE_NAME).account===this.stack.account}grant(grantee,identifier,action,resourceArns,permissionOverrides){return iam.Grant.addToPrincipalOrResource({grantee,actions:[action],resourceArns,resource:{addToResourcePolicy:_statement=>{this.addPermission(identifier,{principal:grantee.grantPrincipal,action,...permissionOverrides});const permissionNode=this._functionNode().tryFindChild(identifier);if(!permissionNode&&!this._skipPermissions)throw new Error("Cannot modify permission to lambda function. Function is either imported or $LATEST version.\nIf the function is imported from the same account use `fromFunctionAttributes()` API with the `sameEnvironment` flag.\nIf the function is imported from a different account and already has the correct permissions use `fromFunctionAttributes()` API with the `skipPermissions` flag.");return{statementAdded:!0,policyDependable:permissionNode}},node:this.node,stack:this.stack,env:this.env,applyRemovalPolicy:this.applyRemovalPolicy}})}parsePermissionPrincipal(principal){if("wrapped"in principal&&(principal=principal.wrapped),"accountId"in principal)return principal.accountId;if("service"in principal)return principal.service;if("arn"in principal)return principal.arn;const stringEquals=matchSingleKey("StringEquals",principal.policyFragment.conditions);if(stringEquals&&matchSingleKey("aws:PrincipalOrgID",stringEquals))return"*";const json=principal.policyFragment.principalJson;if(Object.keys(principal.policyFragment.conditions).length===0&&json.AWS){if(typeof json.AWS=="string")return json.AWS;if(Array.isArray(json.AWS)&&json.AWS.length===1&&typeof json.AWS[0]=="string")return json.AWS[0]}throw new Error(`Invalid principal type for Lambda permission statement: ${principal.constructor.name}. Supported: AccountPrincipal, ArnPrincipal, ServicePrincipal, OrganizationPrincipal`);function matchSingleKey(key,obj){if(Object.keys(obj).length===1)return obj[key]}}validateConditionCombinations(principal){const conditions=this.validateConditions(principal);if(!conditions)return;const sourceArn=requireString(requireObject(conditions.ArnLike)?.["aws:SourceArn"]),sourceAccount=requireString(requireObject(conditions.StringEquals)?.["aws:SourceAccount"]),principalOrgID=requireString(requireObject(conditions.StringEquals)?.["aws:PrincipalOrgID"]);if(principalOrgID&&(sourceArn||sourceAccount))throw new Error("PrincipalWithConditions had unsupported condition combinations for Lambda permission statement: principalOrgID cannot be set with other conditions.");return{sourceArn,sourceAccount,principalOrgID}}validateConditions(principal){if(this.isPrincipalWithConditions(principal)){const conditions=principal.policyFragment.conditions,conditionPairs=util_1.flatMap(Object.entries(conditions),([operator,conditionObjs])=>Object.keys(conditionObjs).map(key=>({operator,key}))),supportedPrincipalConditions=[{operator:"ArnLike",key:"aws:SourceArn"},{operator:"StringEquals",key:"aws:SourceAccount"},{operator:"StringEquals",key:"aws:PrincipalOrgID"}],unsupportedConditions=conditionPairs.filter(condition=>!supportedPrincipalConditions.some(supportedCondition=>supportedCondition.operator===condition.operator&&supportedCondition.key===condition.key));if(unsupportedConditions.length==0)return conditions;throw new Error(`PrincipalWithConditions had unsupported conditions for Lambda permission statement: ${JSON.stringify(unsupportedConditions)}. Supported operator/condition pairs: ${JSON.stringify(supportedPrincipalConditions)}`)}}isPrincipalWithConditions(principal){return Object.keys(principal.policyFragment.conditions).length>0}}exports.FunctionBase=FunctionBase,_a=JSII_RTTI_SYMBOL_1,FunctionBase[_a]={fqn:"aws-cdk-lib.aws_lambda.FunctionBase",version:"2.50.0"};class QualifiedFunctionBase extends FunctionBase{constructor(){super(...arguments),this.permissionsNode=this.node}get latestVersion(){return this.lambda.latestVersion}get resourceArnsForGrantInvoke(){return[this.functionArn]}configureAsyncInvoke(options){try{jsiiDeprecationWarnings.aws_cdk_lib_aws_lambda_EventInvokeConfigOptions(options)}catch(error){throw process.env.JSII_DEBUG!=="1"&&error.name==="DeprecationError"&&Error.captureStackTrace(error,this.configureAsyncInvoke),error}if(this.node.tryFindChild("EventInvokeConfig")!==void 0)throw new Error(`An EventInvokeConfig has already been configured for the qualified function at ${this.node.path}`);new event_invoke_config_1.EventInvokeConfig(this,"EventInvokeConfig",{function:this.lambda,qualifier:this.qualifier,...options})}considerWarningOnInvokeFunctionPermissions(_scope,_action){}}exports.QualifiedFunctionBase=QualifiedFunctionBase,_b=JSII_RTTI_SYMBOL_1,QualifiedFunctionBase[_b]={fqn:"aws-cdk-lib.aws_lambda.QualifiedFunctionBase",version:"2.50.0"};class LatestVersion extends FunctionBase{constructor(lambda){super(lambda,"$LATEST"),this.version="$LATEST",this.permissionsNode=this.node,this.canCreatePermissions=!1,this.lambda=lambda}get functionArn(){return`${this.lambda.functionArn}:${this.version}`}get functionName(){return`${this.lambda.functionName}:${this.version}`}get architecture(){return this.lambda.architecture}get grantPrincipal(){return this.lambda.grantPrincipal}get latestVersion(){return this}get role(){return this.lambda.role}get edgeArn(){throw new Error("$LATEST function version cannot be used for Lambda@Edge")}get resourceArnsForGrantInvoke(){return[this.functionArn]}addAlias(aliasName,options={}){return util_1.addAlias(this,this,aliasName,options)}}function requireObject(x){return x&&typeof x=="object"&&!Array.isArray(x)?x:void 0}function requireString(x){return x&&typeof x=="string"?x:void 0}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ^
TypeError: Cannot read properties of undefined (reading 'role')
    at addToRolePolicy (/Users/caleb/repos/cdk/node_modules/.pnpm/aws-cdk-lib@2.50.0_constructs@10.1.155/node_modules/aws-cdk-lib/aws-lambda/lib/function-base.js:2:1191)
    at Array.forEach (<anonymous>)
    at new AWSAdapterStack (/Users/caleb/repos/cdk/node_modules/.pnpm/sveltekit-adapter-aws@4.3.5_@types+node@10.17.27/node_modules/sveltekit-adapter-aws/lib/adapter-stack.ts:65:45)
    at Object.<anonymous> (/Users/caleb/repos/cdk/deployments/cdk/bin/cdk.ts:43:1)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Module.m._compile (/Users/caleb/repos/cdk/node_modules/.pnpm/ts-node@10.9.1_3f5eba3e7938ffdbdac326efb597c8e9/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/caleb/repos/cdk/node_modules/.pnpm/ts-node@10.9.1_3f5eba3e7938ffdbdac326efb597c8e9/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.Module._load (node:internal/modules/cjs/loader:839:12)

Subprocess exited with error 1
```