### PR TITLE
Add option to override esbuild config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export interface AWSAdapterProps {
   artifactPath?: string; // Build output directory (default: build)
   autoDeploy?: boolean; // Should automatically deploy in SvelteKit build step (default: false)
   stackName?: string; // AWS-CDK CloudFormation Stackname (default: AWSAdapterStack-Default)
+  esbuildOptions?: any; // Override or extend default esbuild options. Supports `external` (default `['node:*']`), `format` (default `cjs`), `target` (default `node16`).
   FQDN?: string; // Full qualified domain name of CloudFront deployment (e.g. demo.example.com)
   MEMORY_SIZE?: number; // Memory size of SSR lambda in MB (default 128 MB)
   LOG_RETENTION_DAYS?: number; // Log retention in days of SSR lambda (default 7 days)

--- a/adapter.ts
+++ b/adapter.ts
@@ -11,6 +11,7 @@ export interface AWSAdapterProps {
   autoDeploy?: boolean;
   cdkProjectPath?: string;
   stackName?: string;
+  esbuildOptions?: any;
   FQDN?: string;
   LOG_RETENTION_DAYS?: number;
   MEMORY_SIZE?: number;
@@ -22,6 +23,7 @@ export function adapter({
   autoDeploy = false,
   cdkProjectPath = `${__dirname}/deploy/index.js`,
   stackName = 'sveltekit-adapter-aws-webapp',
+  esbuildOptions = {},
   FQDN,
   LOG_RETENTION_DAYS,
   MEMORY_SIZE,
@@ -62,11 +64,11 @@ export function adapter({
         entryPoints: [`${server_directory}/_index.js`],
         outfile: `${server_directory}/index.js`,
         inject: [join(`${server_directory}/shims.js`)],
-        external: ['node:*'],
-        format: 'cjs',
+        external: ['node:*', ...(esbuildOptions?.external ?? [])],
+        format: esbuildOptions?.format ?? 'cjs',
         bundle: true,
         platform: 'node',
-        target: 'es2020',
+        target: esbuildOptions?.target ?? 'node16',
         treeShaking: true,
       });
 


### PR DESCRIPTION
I ran into `No loader is configured for ".node" files: node_modules/@node-rs/argon2-darwin-arm64/argon2.darwin-arm64.node`. There is an esbuild workaround (https://github.com/evanw/esbuild/issues/1051#issuecomment-806325487), but I think a Lamba Layer will be better approach in this case. To achieve this I needed to be able to override the esbuild options.

While I was at it I added in override for `format` and `target`. I can't imagine any others that can be required.

Sorry the TS isn't as good as it could be.

Thanks for supporting such a useful package.