### PR TITLE
(fix): deploying app to root domain

### DIFF
--- a/lib/adapter-stack.ts
+++ b/lib/adapter-stack.ts
@@ -45,7 +45,7 @@ export class AWSAdapterStack extends Stack {
     const logRetention = parseInt(process.env.LOG_RETENTION_DAYS!) || 7;
     const memorySize = parseInt(process.env.MEMORY_SIZE!) || 128;
     const environment = config({ path: projectPath });
-    const [_, zoneName, TLD] = process.env.FQDN?.split('.') || [];
+    const [zoneName, TLD] = process.env.FQDN?.split('.').slice(-2) || [];
     const domainName = `${zoneName}.${TLD}`;
 
     this.serverHandler = new aws_lambda.Function(this, 'LambdaServerFunctionHandler', {


### PR DESCRIPTION
there's a bug when deploying an application to the root domain e.g example.com instead of www.example.com

```
/Users/scullion/Development/ConnectMor/revision-ninja/node_modules/sveltekit-adapter-aws/node_modules/aws-cdk-lib/core/lib/private/synthesis.js:2
  `);throw new Error(`Validation failed with the following errors:
     ^

Error: Validation failed with the following errors:
  [revision-ninja-sveltekit-stack/DnsValidatedCertificate] DNS zone ninja.undefined is not authoritative for certificate domain name revision.ninja
    at validateTree (/Users/scullion/Development/ConnectMor/revision-ninja/node_modules/sveltekit-adapter-aws/node_modules/aws-cdk-lib/core/lib/private/synthesis.js:2:12)
    at Object.synthesize (/Users/scullion/Development/ConnectMor/revision-ninja/node_modules/sveltekit-adapter-aws/node_modules/aws-cdk-lib/core/lib/private/synthesis.js:1:647)
    at App.synth (/Users/scullion/Development/ConnectMor/revision-ninja/node_modules/sveltekit-adapter-aws/node_modules/aws-cdk-lib/core/lib/stage.js:1:1883)
    at process.<anonymous> (/Users/scullion/Development/ConnectMor/revision-ninja/node_modules/sveltekit-adapter-aws/node_modules/aws-cdk-lib/core/lib/app.js:1:1157)
    at Object.onceWrapper (node:events:628:26)
    at process.emit (node:events:513:28)

Node.js v18.8.0
```