### PR TITLE
add support for different zone names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ export interface AWSAdapterProps {
   FQDN?: string; // Full qualified domain name of CloudFront deployment (e.g. demo.example.com)
   MEMORY_SIZE?: number; // Memory size of SSR lambda in MB (default 128 MB)
   LOG_RETENTION_DAYS?: number; // Log retention in days of SSR lambda (default 7 days)
+  zoneName?: string; // The name of the hosted zone in Route 53 (defaults to the TLD from the FQDN)
 }
 ```
 

--- a/adapter.ts
+++ b/adapter.ts
@@ -15,6 +15,7 @@ export interface AWSAdapterProps {
   FQDN?: string;
   LOG_RETENTION_DAYS?: number;
   MEMORY_SIZE?: number;
+  zoneName?: string;
   env?: { [key: string]: string };
 }
 
@@ -27,6 +28,7 @@ export function adapter({
   FQDN,
   LOG_RETENTION_DAYS,
   MEMORY_SIZE,
+  zoneName = '',
   env = {},
 }: AWSAdapterProps = {}) {
   /** @type {import('@sveltejs/kit').Adapter} */
@@ -125,6 +127,7 @@ export function adapter({
                 FQDN,
                 LOG_RETENTION_DAYS,
                 MEMORY_SIZE,
+                ZONE_NAME: zoneName,
               },
               process.env,
               env

--- a/deploy/index.ts
+++ b/deploy/index.ts
@@ -7,6 +7,7 @@ Tags.of(app).add('app', 'sveltekit-adapter-aws-webapp');
 
 new AWSAdapterStack(app, process.env.STACKNAME!, {
   FQDN: process.env.FQDN!,
+  zoneName: process.env.ZONE_NAME!,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/lib/adapter-stack.ts
+++ b/lib/adapter-stack.ts
@@ -25,6 +25,7 @@ export interface AWSAdapterStackProps extends StackProps {
   account?: string;
   region?: string;
   serverHandlerPolicies?: PolicyStatement[];
+  zoneName?: string;
 }
 
 export class AWSAdapterStack extends Stack {
@@ -46,7 +47,7 @@ export class AWSAdapterStack extends Stack {
     const memorySize = parseInt(process.env.MEMORY_SIZE!) || 128;
     const environment = config({ path: projectPath });
     const [zoneName, TLD] = process.env.FQDN?.split('.').slice(-2) || [];
-    const domainName = `${zoneName}.${TLD}`;
+    const domainName = process.env.ZONE_NAME || `${zoneName}.${TLD}`;
 
     this.serverHandler = new aws_lambda.Function(this, 'LambdaServerFunctionHandler', {
       code: new aws_lambda.AssetCode(serverPath!),


### PR DESCRIPTION
The current code makes the assumption that the hosted zone will always use the name of the top level domain. My setup is to host my root level DNS with a different provider and then delegate individual subdomains to Route 53 instead, so the zone name for my application is actually the same as my FQDN. This setup is also common in big companies where the root domain will be managed in one AWS account, and then it will delegate a subdomain like `stage.companyname.com` to a separate AWS account. Because of my setup though, CDK can't find my hosted zone and deployment fails.

This appears to do the trick by allowing a `zoneName` to be provided in the options. I figure this is a bit of an edge case so by default it won't be needed, but it can be added for people with cases like mine.