### PR TITLE
fix: support multi-level domains

### DIFF
--- a/lib/adapter-stack.ts
+++ b/lib/adapter-stack.ts
@@ -45,8 +45,8 @@ export class AWSAdapterStack extends Stack {
     const logRetention = parseInt(process.env.LOG_RETENTION_DAYS!) || 7;
     const memorySize = parseInt(process.env.MEMORY_SIZE!) || 128;
     const environment = config({ path: projectPath });
-    const [zoneName, TLD] = process.env.FQDN?.split('.').slice(-2) || [];
-    const domainName = `${zoneName}.${TLD}`;
+    const [_, zoneName, ...MLDs] = process.env.FQDN?.split('.') || [];
+    const domainName = [zoneName, ...MLDs].join(".");
 
     this.serverHandler = new aws_lambda.Function(this, 'LambdaServerFunctionHandler', {
       code: new aws_lambda.AssetCode(serverPath!),


### PR DESCRIPTION
# Fails to deploying to a 3rd level domain

## Configuration

FQDN = "www.hi2.me.uk"

## Result

AWS CDK reports:

DNS zone **hi2.me** is not authoritative for certificate domain name [www.hi2.me.uk](http://www.hi2.me.uk/)

## Expected Result

Deployment succeeds.

## Cause

lib/adapter-stack.ts assumes all top level domains are always 2 level e.g. example.com. whereas it could be mydomain.co.uk
