### PR TITLE
fix: move RequestOptions outside of Request

### DIFF
--- a/lambda/serverless.js
+++ b/lambda/serverless.js
@@ -15,19 +15,16 @@ export async function handler(event) {
   await server.init({ env: process.env });
 
   const rendered = await server.respond(
-    new Request(
-      rawURL,
-      {
-        method,
-        headers: new Headers(headers || {}),
-        body: rawBody,
+    new Request(rawURL, {
+      method,
+      headers: new Headers(headers || {}),
+      body: rawBody,
+    }),
+    {
+      getClientAddress() {
+        return headers.get('x-forwarded-for');
       },
-      {
-        getClientAddress() {
-          return headers.get('x-forwarded-for');
-        },
-      }
-    )
+    }
   );
 
   if (rendered) {


### PR DESCRIPTION
I discovered the cause of the #21, RequestOptions inadvertently placed inside the Request instance, which should have been the second argument to server.respond.