### PR TITLE
fix: patch for sveltekit v 1.5

### DIFF
--- a/lambda/serverless.js
+++ b/lambda/serverless.js
@@ -13,21 +13,21 @@ export async function handler(event) {
   const rawURL = `${headers.origin}${path}${parseQuery(multiValueQueryStringParameters)}`;
 
   await server.init({ env: process.env });
-
+  const request = new Request(
+    rawURL,
+    {
+      method,
+      headers: new Headers(headers || {}),
+      body: rawBody,
+    },
+  )
   const rendered = await server.respond(
-    new Request(
-      rawURL,
-      {
-        method,
-        headers: new Headers(headers || {}),
-        body: rawBody,
+    request,
+    {
+      getClientAddress() {
+        return headers.get('x-forwarded-for')
       },
-      {
-        getClientAddress() {
-          return headers.get('x-forwarded-for');
-        },
-      }
-    )
+    }
   );
 
   if (rendered) {


### PR DESCRIPTION
I recently updated my @sveltejs/kit package in my SvelteKit app and it caused the handler to break. I think it has something to do with a possible change in the Server class that gets imported.  I found this small change fixed things.

Haven't tested if this works with `@sveltejs/kit": "1.0.0-next.561` 
Just putting this here for when you decide to update the version of SvelteKit and hopefully don't run into the same headache I just did :)