### PR TITLE
feat: add in esbuid option for banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export interface AWSAdapterProps {
   artifactPath?: string; // Build output directory (default: build)
   autoDeploy?: boolean; // Should automatically deploy in SvelteKit build step (default: false)
   stackName?: string; // AWS-CDK CloudFormation Stackname (default: AWSAdapterStack-Default)
-  esbuildOptions?: any; // Override or extend default esbuild options. Supports `external` (default `['node:*']`), `format` (default `cjs`), `target` (default `node16`).
+  esbuildOptions?: any; // Override or extend default esbuild options. Supports `external` (default `['node:*']`), `format` (default `cjs`), `target` (default `node16`), `banner` (default `{}`).
   FQDN?: string; // Full qualified domain name of CloudFront deployment (e.g. demo.example.com)
   MEMORY_SIZE?: number; // Memory size of SSR lambda in MB (default 128 MB)
   LOG_RETENTION_DAYS?: number; // Log retention in days of SSR lambda (default 7 days)

--- a/adapter.ts
+++ b/adapter.ts
@@ -68,6 +68,7 @@ export function adapter({
         inject: [join(`${server_directory}/shims.js`)],
         external: ['node:*', ...(esbuildOptions?.external ?? [])],
         format: esbuildOptions?.format ?? 'cjs',
+        banner: esbuildOptions?.banner ?? {},
         bundle: true,
         platform: 'node',
         target: esbuildOptions?.target ?? 'node16',


### PR DESCRIPTION
esbuild doesn't support dynamic imports and nested commonjs imports well when using `format:"esm"`. A work around is required, most commonly via the `banner` argument.

Sample usage:
```
esbuildOptions: {
        format: 'esm',
        target: 'node18',
        banner: {
          js: `
import { createRequire } from 'module';
import path from 'path';
import { fileURLToPath } from 'url';
const require = createRequire(import.meta.url);
const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
`
        }
      }
```