### PR TITLE
Correctly handle multiple set-cookie headers

### DIFF
--- a/lambda/serverless.js
+++ b/lambda/serverless.js
@@ -32,9 +32,9 @@ export async function handler(event) {
 
   if (rendered) {
     const resp = {
-			statusCode: rendered.status,
+      statusCode: rendered.status,
       body: await rendered.text(),
-			...split_headers(rendered.headers)
+      ...split_headers(rendered.headers),
     };
     resp.headers['Cache-Control'] = 'no-cache';
     return resp;
@@ -83,28 +83,28 @@ function parseQuery(queryParams) {
  * Splits headers into two categories: single value and multi value
  * @param {Headers} headers
  * @returns {{
-*   headers: Record<string, string>,
-*   multiValueHeaders: Record<string, string[]>
-* }}
-*/
+ *   headers: Record<string, string>,
+ *   multiValueHeaders: Record<string, string[]>
+ * }}
+ */
 export function split_headers(headers) {
-	/** @type {Record<string, string>} */
-	const h = {};
+  /** @type {Record<string, string>} */
+  const h = {};
 
-	/** @type {Record<string, string[]>} */
-	const m = {};
+  /** @type {Record<string, string[]>} */
+  const m = {};
 
-	headers.forEach((value, key) => {
-		if (key === 'set-cookie') {
-			if (!m[key]) m[key] = [];
-			m[key].push(...setCookie.splitCookiesString(value));
-		} else {
-			h[key] = value;
-		}
-	});
+  headers.forEach((value, key) => {
+    if (key === 'set-cookie') {
+      if (!m[key]) m[key] = [];
+      m[key].push(...setCookie.splitCookiesString(value));
+    } else {
+      h[key] = value;
+    }
+  });
 
-	return {
-		headers: h,
-		multiValueHeaders: m
-	};
+  return {
+    headers: h,
+    multiValueHeaders: m,
+  };
 }

--- a/lib/adapter-stack.ts
+++ b/lib/adapter-stack.ts
@@ -47,7 +47,7 @@ export class AWSAdapterStack extends Stack {
     const memorySize = parseInt(process.env.MEMORY_SIZE!) || 128;
     const environment = config({ path: projectPath });
     const [_, zoneName, ...MLDs] = process.env.FQDN?.split('.') || [];
-    const domainName = [zoneName, ...MLDs].join(".");
+    const domainName = [zoneName, ...MLDs].join('.');
 
     this.serverHandler = new aws_lambda.Function(this, 'LambdaServerFunctionHandler', {
       code: new aws_lambda.AssetCode(serverPath!),

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/fs-extra": "11.0.1",
     "@types/node": "18.14.0",
     "@types/node-fetch": "2.6.2",
+    "@types/set-cookie-parser": "^2.4.2",
     "esbuild": "0.17.10",
     "prettier": "2.8.4",
     "typescript": "4.9.5"
@@ -45,6 +46,7 @@
     "constructs": "10.1.257",
     "dotenv": "16.0.3",
     "fs-extra": "11.1.0",
+    "set-cookie-parser": "^2.5.1",
     "svelte": "3.55.1",
     "update-dotenv": "1.1.1",
     "vite": "4.1.4"


### PR DESCRIPTION
This PR changes how set-cookies headers with multiple values are returned. Previously, the code looks for Array types in the headers property, but multiple values are actually stored as a comma delimited list. 

Following the adapter-netlify approach, the set-cookie-parser package is used here to split the set-cookie header while all other headers are left unchanged.