### PR TITLE
Fix setting multiple cookies

### DIFF
--- a/lambda/serverless.js
+++ b/lambda/serverless.js
@@ -37,11 +37,17 @@ export async function handler(event) {
       multiValueHeaders: {},
       body: await rendered.text(),
       statusCode: rendered.status,
+      cookies: []
     };
 
     for (let k of rendered.headers.keys()) {
       const v = rendered.headers.get(k);
-      if (v instanceof Array) {
+      if(k.toLowerCase() === "set-cookie") {
+        resp.cookies.push(
+          ...v.split(',')
+          .map((s) => s.trim())
+        );
+      }else if (v instanceof Array) {
         resp.multiValueHeaders[k] = v;
       } else {
         resp.headers[k] = v;


### PR DESCRIPTION
We could not set multiple cookies at once using the adapter as is.
This commit now uses the `cookies` property in the response and pushes the respective values in there.