### PR TITLE
Make sveltekit minor version flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "2.66.0-alpha.0",
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.66.0-alpha.0",
-    "@sveltejs/kit": "1.8.3",
+    "@sveltejs/kit": "^1.8.3",
     "aws-cdk": "2.66.0",
     "aws-cdk-lib": "2.66.0",
     "constructs": "10.1.257",


### PR DESCRIPTION
This is a potential fix for issue #37 

I haven't tested it, I'm not sure exactly how to do that. However I figured that opening a PR is a way to get the ball rolling on fixing the issue.

I made the sveltekit version flexible so that the project can use the same sveltekit version as the user, as long as it is >= 1.8.3 and < 2.0.0
That should fix issue #37 and any future security warnings that may arise from a fixed sveltekit version.